### PR TITLE
Add routertype driver callouts to L3 Plugin

### DIFF
--- a/networking_cisco/plugins/cisco/l3/drivers/__init__.py
+++ b/networking_cisco/plugins/cisco/l3/drivers/__init__.py
@@ -201,6 +201,25 @@ class L3RouterBaseDriver(object):
         pass
 
     @abc.abstractmethod
+    def create_floatingip_postcommit(self, context, fip_context):
+        """Create a floatingip.
+
+        :param context: the neutron context of the request
+        :param fip_context: FloatingipContext instance describing the new
+        state of the floatingip
+
+        Called after the transaction commits. Call can block, though will
+        block the entire process so care should be taken to not drastically
+        affect performance. Raising an exception will cause the deletion of
+        the resource.
+
+        create_flotingip_postcommit is called for all changes to the router
+        state.  It is up to the routertype driver to ignore state or state
+        changes that it does not know or care about.
+        """
+        pass
+
+    @abc.abstractmethod
     def update_floatingip_precommit(self, context, fip_context):
         """Perform operations specific to the routertype in preparation for
         the update of a floatingip.

--- a/networking_cisco/plugins/cisco/l3/drivers/asr1k/asr1k_routertype_driver.py
+++ b/networking_cisco/plugins/cisco/l3/drivers/asr1k/asr1k_routertype_driver.py
@@ -115,6 +115,9 @@ class ASR1kL3RouterDriver(drivers.L3RouterBaseDriver):
     def remove_router_interface_postcommit(self, context, r_port_context):
         pass
 
+    def create_floatingip_postcommit(self, context, fip_context):
+        pass
+
     def update_floatingip_precommit(self, context, fip_context):
         pass
 

--- a/networking_cisco/plugins/cisco/l3/drivers/noop_routertype_driver.py
+++ b/networking_cisco/plugins/cisco/l3/drivers/noop_routertype_driver.py
@@ -59,6 +59,9 @@ class NoopL3RouterDriver(drivers.L3RouterBaseDriver):
     def remove_router_interface_postcommit(self, context, r_port_context):
         pass
 
+    def create_floatingip_postcommit(self, context, fip_context):
+        pass
+
     def update_floatingip_precommit(self, context, fip_context):
         pass
 


### PR DESCRIPTION
The L3 plugin doesn't have callouts for all of the Router
Type driver APIs. This patch adds the missing callouts. It
also adds a create floating IP postcommit API to the Router
Type driver APIs, adds this API to the existing drivers, and
adds the callout for it in the L3 plugin.

Closes-Bug: #1603269

Signed-off-by: Thomas Bachman tbachman@yahoo.com
