### PR TITLE
Added floating IP precommit call

### DIFF
--- a/networking_cisco/plugins/cisco/l3/drivers/__init__.py
+++ b/networking_cisco/plugins/cisco/l3/drivers/__init__.py
@@ -201,6 +201,26 @@ class L3RouterBaseDriver(object):
         pass
 
     @abc.abstractmethod
+    def create_floatingip_precommit(self, context, fip_context):
+        """Create a floatingip.
+
+        :param context: the neutron context of the request
+        :param fip_context: FloatingipContext instance describing the new
+        state of the floatingip
+
+        Called before the transaction commits. Call can block, though will
+        block the entire process so care should be taken to not drastically
+        affect performance. Raising an exception will cause the deletion of
+        the resource.
+
+        create_flotingip_precommit will not be used by most drivers. The
+        only way a routertype driver can be known is to assume the default
+        router type. This API was introduced to support allocation of
+        floating IPs from NAT pools for Group Based Policy (GBP) workflow.
+        """
+        pass
+
+    @abc.abstractmethod
     def create_floatingip_postcommit(self, context, fip_context):
         """Create a floatingip.
 

--- a/networking_cisco/plugins/cisco/l3/drivers/asr1k/asr1k_routertype_driver.py
+++ b/networking_cisco/plugins/cisco/l3/drivers/asr1k/asr1k_routertype_driver.py
@@ -115,6 +115,9 @@ class ASR1kL3RouterDriver(drivers.L3RouterBaseDriver):
     def remove_router_interface_postcommit(self, context, r_port_context):
         pass
 
+    def create_floatingip_precommit(self, context, fip_context):
+        pass
+
     def create_floatingip_postcommit(self, context, fip_context):
         pass
 

--- a/networking_cisco/plugins/cisco/l3/drivers/noop_routertype_driver.py
+++ b/networking_cisco/plugins/cisco/l3/drivers/noop_routertype_driver.py
@@ -59,6 +59,9 @@ class NoopL3RouterDriver(drivers.L3RouterBaseDriver):
     def remove_router_interface_postcommit(self, context, r_port_context):
         pass
 
+    def create_floatingip_precommit(self, context, fip_context):
+        pass
+
     def create_floatingip_postcommit(self, context, fip_context):
         pass
 


### PR DESCRIPTION
This adds a precommit API for floating IP creation. This
API is used with Group Based Policy workflow.

Partial-Bug: #1604035

Signed-off-by: Thomas Bachman tbachman@yahoo.com
