### PR TITLE
Added GBP workflow for floating IPs

### DIFF
--- a/networking_cisco/plugins/cisco/db/l3/l3_router_appliance_db.py
+++ b/networking_cisco/plugins/cisco/db/l3/l3_router_appliance_db.py
@@ -120,6 +120,7 @@ class L3RouterApplianceDBMixin(extraroute_db.ExtraRoute_dbonly_mixin):
     _backlogged_routers = set()
     _refresh_router_backlog = True
     _heartbeat = None
+    _is_gbp_workflow = None
 
     db_base_plugin_v2.NeutronDbPluginV2.register_dict_extend_funcs(
         l3.ROUTERS, ['_extend_router_dict_routertype',
@@ -520,8 +521,80 @@ class L3RouterApplianceDBMixin(extraroute_db.ExtraRoute_dbonly_mixin):
             driver.remove_router_interface_postcommit(context, port_ctxt)
         return info
 
+    @property
+    def is_gbp_workflow(self):
+        """Determine if Group Based Policy service plugin is used.
+
+        The behavior of some floating IP APIs is slightly different
+        when GBP workflow is used.
+        """
+
+        if self._is_gbp_workflow is None:
+            try:
+                if manager.NeutronManager.get_service_plugins()[
+                        'GROUP_POLICY']:
+                    self._is_gbp_workflow = True
+            except KeyError:
+                self._is_gbp_workflow = False
+        return self._is_gbp_workflow
+
     def create_floatingip(self, context, floatingip,
                           initial_status=FLOATINGIP_STATUS_ACTIVE):
+        if self.is_gbp_workflow:
+            return self._create_floatingip_gbp(context,
+                floatingip, initial_status=FLOATINGIP_STATUS_ACTIVE)
+        else:
+            return self._create_floatingip_neutron(context,
+                floatingip, initial_status=FLOATINGIP_STATUS_ACTIVE)
+
+    def _create_floatingip_gbp(self, context, floatingip,
+                               initial_status=FLOATINGIP_STATUS_ACTIVE):
+        """Group Based Policy hanlding of Floating IP Creation.
+
+        This version of the create_flaotingip is needed for the GBP workflow,
+        as the pre-/post-commmit calls for creating the floating IP must be
+        peformed in a loop with the database call in the grandparent class.
+        """
+
+        result = None
+        fip = floatingip['floatingip']
+        if not fip.get('subnet_id'):
+            # NOTE: default router type must be ASR1k
+            router_type_name = cfg.CONF.routing.default_router_type
+            driver = self._get_router_type_driver(context,
+                                                  router_type_name)
+            if driver:
+                fip_ctxt = driver_context.FloatingipContext(floatingip)
+                driver.create_floatingip_precommit(context, fip_ctxt)
+                nat_pool_list = getattr(context, 'nat_pool_list', [])
+                for nat_pool in nat_pool_list:
+                    if not nat_pool:
+                        continue
+                    fip['subnet_id'] = nat_pool['subnet_id']
+                    try:
+                        result = super(L3RouterApplianceDBMixin,
+                                    self).create_floatingip(context,
+                                                            floatingip)
+                        router_ids = ([result['router_id']]
+                                      if result['router_id'] else [])
+                    except n_exc.IpAddressGenerationFailure as ex:
+                        LOG.info(_LI("Floating allocation failed: %s"),
+                                 ex.message)
+                    if result:
+                        break
+        if not result:
+            result = super(L3RouterApplianceDBMixin,
+                           self).create_floatingip(context,
+                                                   floatingip, initial_status)
+            router_ids = [result['router_id']] if result['router_id'] else []
+        context.result = result
+        if driver:
+            driver.create_floatingip_postcommit(context, fip_ctxt)
+        self._notify_affected_routers(context, router_ids, 'create_floatingip')
+        return result
+
+    def _create_floatingip_neutron(self, context, floatingip,
+                                   initial_status=FLOATINGIP_STATUS_ACTIVE):
         info = super(L3RouterApplianceDBMixin, self).create_floatingip(
             context, floatingip, initial_status)
         router_ids = [info['router_id']] if info['router_id'] else []
@@ -537,7 +610,14 @@ class L3RouterApplianceDBMixin(extraroute_db.ExtraRoute_dbonly_mixin):
         self._notify_affected_routers(context, router_ids, 'create_floatingip')
         return info
 
-    def update_floatingip(self, context, floatingip_id, floatingip):
+    def _do_update_floatingip(self, context, floatingip_id,
+                           floatingip, add_fip=False):
+        """Modified version of update_floatingip.
+
+        This modifies the existing update_floatingip call with a flag
+        used to add the result of the superclass call to the context
+        for the postcommit call.
+        """
         orig_fl_ip = super(L3RouterApplianceDBMixin, self).get_floatingip(
             context, floatingip_id)
         before_router_id = orig_fl_ip['router_id']
@@ -567,9 +647,19 @@ class L3RouterApplianceDBMixin(extraroute_db.ExtraRoute_dbonly_mixin):
                 fip_ctxt = driver_context.FloatingipContext(
                     floatingip.get('floatingip'), orig_fl_ip)
             if driver:
+                if add_fip:
+                    context.result = info
                 driver.update_floatingip_postcommit(context, fip_ctxt)
         self._notify_affected_routers(context, router_ids, 'update_floatingip')
         return info
+
+    def update_floatingip(self, context, floatingip_id, floatingip):
+        if self.is_gbp_workflow:
+            return self._do_update_floatingip(context, floatingip_id,
+                                              floatingip, add_fip=True)
+        else:
+            return self._do_update_floatingip(context,
+                                              floatingip_id, floatingip)
 
     def delete_floatingip(self, context, floatingip_id):
         floatingip_db = self._get_floatingip(context, floatingip_id)

--- a/networking_cisco/tests/unit/cisco/l3/test_l3_router_appliance_plugin.py
+++ b/networking_cisco/tests/unit/cisco/l3/test_l3_router_appliance_plugin.py
@@ -18,13 +18,16 @@ import mock
 from oslo_config import cfg
 from oslo_db import exception as db_exc
 from oslo_log import log as logging
+from oslo_utils import uuidutils
 import six
 from sqlalchemy import exc as inner_db_exc
 
 
 from neutron.api.v2 import attributes
+from neutron.common import constants as l3_constants
 from neutron import context as n_context
 from neutron.db import agents_db
+from neutron.extensions import external_net as external_net
 from neutron.extensions import extraroute
 from neutron.extensions import l3
 from neutron.extensions import providernet as pnet
@@ -48,6 +51,7 @@ from networking_cisco.tests.unit.cisco.l3 import l3_router_test_support
 from networking_cisco.tests.unit.cisco.l3 import test_db_routertype
 
 LOG = logging.getLogger(__name__)
+_uuid = uuidutils.generate_uuid
 
 
 CORE_PLUGIN_KLASS = device_manager_test_support.CORE_PLUGIN_KLASS
@@ -682,3 +686,113 @@ class L3CfgAgentRouterApplianceTestCase(L3RouterApplianceTestCaseBase,
             res = self.plugin._allocate_hosting_port(
                 ctx_mock, r_id, p1_db, 'fake_hd_id', plugging_drv_mock)
             self.assertIsNone(res)
+
+
+class L3RouterApplianceGbpTestCase(test_l3.L3NatTestCaseMixin,
+                                   L3RouterApplianceTestCaseBase):
+
+    router_type = "ASR1k_Neutron_router"
+
+    def setUp(self, core_plugin=None, l3_plugin=None, dm_plugin=None,
+              ext_mgr=None):
+        super(L3RouterApplianceGbpTestCase, self).setUp(
+            core_plugin=core_plugin, l3_plugin=l3_plugin, dm_plugin=dm_plugin,
+            ext_mgr=ext_mgr)
+        self._created_mgmt_nw = False
+        self.saved_service_plugins = manager.NeutronManager.get_service_plugins
+        manager.NeutronManager.get_service_plugins = mock.Mock(
+            return_value={'GROUP_POLICY': object(),
+                          service_constants.L3_ROUTER_NAT: self}
+        )
+
+    def tearDown(self):
+        super(L3RouterApplianceGbpTestCase, self).tearDown()
+        manager.NeutronManager.get_service_plugins = self.saved_service_plugins
+
+    def test_is_gbp_workflow(self):
+        self.assertTrue(self.plugin.is_gbp_workflow)
+
+    def test_create_floatingip_gbp(self):
+        kwargs = {'arg_list': (external_net.EXTERNAL,),
+                  external_net.EXTERNAL: True}
+        self.plugin._update_fip_assoc = mock.Mock()
+        with self.network(**kwargs) as net:
+            with self.subnet(network=net, cidr='200.0.0.0/22') as sub:
+                subnet = sub['subnet']
+                # dummy func is used to verify that our stub was called
+                dummy_func = mock.Mock()
+
+                def _stub_modify_context(context, fip_context):
+                    context.nat_pool_list = [{'subnet_id': subnet['id']}]
+                    dummy_func(context)
+
+                mock_drvr = mock.Mock()
+                mock_drvr.create_floatingip_precommit = _stub_modify_context
+                self.plugin._get_router_type_driver = mock.Mock(
+                    return_value=mock_drvr
+                )
+                network = net['network']
+                floating_ip = {
+                    'floatingip': {'floating_network_id': network['id'],
+                                   'tenant_id': net['network']['tenant_id']}
+                }
+                ctx = n_context.get_admin_context()
+                self.plugin.create_floatingip(ctx, floating_ip)
+                dummy_func.assert_called_once_with(ctx)
+                mock_drvr.create_floatingip_postcommit.assert_called_once_with(
+                    ctx, mock.ANY)
+                self.plugin._update_fip_assoc.assert_called_once_with(ctx,
+                    mock.ANY, mock.ANY, mock.ANY)
+
+    def test_update_floatingip_gbp(self):
+        self.plugin._do_update_floatingip = mock.Mock()
+        ctx = n_context.get_admin_context()
+        TEST_FIP_UUID = _uuid()
+        floating_ip = {
+            'floatingip': {'floating_network_id': _uuid()}
+        }
+        self.plugin.update_floatingip(ctx, TEST_FIP_UUID, floating_ip)
+        self.plugin._do_update_floatingip.assert_called_once_with(ctx,
+            TEST_FIP_UUID, floating_ip, add_fip=True)
+
+
+class L3RouterApplianceNoGbpTestCase(test_l3.L3NatTestCaseMixin,
+                                     L3RouterApplianceTestCaseBase):
+    router_type = "ASR1k_Neutron_router"
+
+    def setUp(self, core_plugin=None, l3_plugin=None, dm_plugin=None,
+              ext_mgr=None):
+        super(L3RouterApplianceNoGbpTestCase, self).setUp(
+            core_plugin=core_plugin, l3_plugin=l3_plugin, dm_plugin=dm_plugin,
+            ext_mgr=ext_mgr)
+        self._created_mgmt_nw = False
+
+    def tearDown(self):
+        super(L3RouterApplianceNoGbpTestCase, self).tearDown()
+
+    def test_is_not_gbp_workflow(self):
+        self.assertFalse(self.plugin.is_gbp_workflow)
+
+    def test_create_floatingip_gbp(self):
+        self.plugin._update_fip_assoc = mock.Mock()
+        self.plugin._create_floatingip_neutron = mock.Mock()
+        self.plugin._create_floatingip_gbp = mock.Mock()
+        ctx = n_context.get_admin_context()
+        floating_ip = {
+            'floatingip': {'floating_network_id': _uuid()}
+        }
+        self.plugin.create_floatingip(ctx, floating_ip)
+        self.plugin._create_floatingip_gbp.assert_not_called()
+        self.plugin._create_floatingip_neutron.assert_called_once_with(ctx,
+            floating_ip, initial_status=l3_constants.FLOATINGIP_STATUS_ACTIVE)
+
+    def test_update_floatingip_no_gbp(self):
+        self.plugin._do_update_floatingip = mock.Mock()
+        ctx = n_context.get_admin_context()
+        TEST_FIP_UUID = _uuid()
+        floating_ip = {
+            'floatingip': {'floating_network_id': _uuid()}
+        }
+        self.plugin.update_floatingip(ctx, TEST_FIP_UUID, floating_ip)
+        self.plugin._do_update_floatingip.assert_called_once_with(ctx,
+            TEST_FIP_UUID, floating_ip)


### PR DESCRIPTION
This adds support for using Group Based Policy (GBP) workflow
with the Cisco Router Service Plugin. It modifies the floating
IP APIs to support allocation of FIPs from NAT pools.

Partial-Bug: #1604035

Signed-off-by: Thomas Bachman tbachman@yahoo.com
