### PR TITLE
Add ACI Driver external networks file

### DIFF
--- a/etc/neutron/plugins/cisco/aci_asr_config.ini
+++ b/etc/neutron/plugins/cisco/aci_asr_config.ini
@@ -1,0 +1,7 @@
+{
+    'Datacenter-Out': {
+        'gateway_ip': '1.103.2.254',
+        'cidr_exposed': '1.103.2.1/24',
+        'segmentation_id': 3003
+    }
+}


### PR DESCRIPTION
This adds a file used to dynamically add external network
configuration information needed by the ACI/ASR plugging driver.

Signed-off-by: Thomas Bachman tbachman@yahoo.com
