### PR TITLE
Fix liberty RPM build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,10 @@
 pbr<2.0,>=1.4
 
 Babel>=1.3
-ncclient>=0.4.2;python_version<'3.0'
+ncclient>=0.4.2
 lxml>=3.3.3
-UcsSdk<=0.8.2;python_version<'3.0'
+UcsSdk<=0.8.2
+python_version<'3.0' # requirement from ncclient and UcsSdk
 
 oslo.config>=2.3.0  # Apache-2.0
 oslo.concurrency>=2.3.0         # Apache-2.0


### PR DESCRIPTION
This fixes an issue with RPM builds for liberty
(failed on using format of specifying python version
after version for another package).

Signed-off-by: Thomas Bachman tbachman@yahoo.com
