### PR TITLE
Added cfg-agent configuration file

### DIFF
--- a/etc/cfg-agent/init/neutron-cisco-cfg-agent.conf
+++ b/etc/cfg-agent/init/neutron-cisco-cfg-agent.conf
@@ -1,0 +1,19 @@
+description "Neutron Cisco Configuration Agent"
+
+start on runlevel [2345]
+stop on runlevel [!2345]
+
+respawn
+
+chdir /var/run
+
+pre-start script
+  mkdir -p /var/run/neutron
+  chown neutron:root /var/run/neutron
+end script
+
+exec start-stop-daemon --start --chuid neutron \
+  --exec /usr/bin/neutron-cisco-cfg-agent -- \
+  --config-file=/etc/neutron/neutron.conf \
+  --config-file=/etc/neutron/plugins/cisco/cisco_cfg_agent.ini \
+  --log-file=/var/log/neutron/cisco-configuration-agent.log


### PR DESCRIPTION
This adds a configuration file for the configuration agent.
This is needed when creating debian packaging.

Signed-off-by: Thomas Bachman tbachman@yahoo.com
