### PR TITLE
Fix SNAT pool name when associating with ACL

### DIFF
--- a/networking_cisco/tests/unit/cisco/cfg_agent/test_aciasr1k_routing_driver.py
+++ b/networking_cisco/tests/unit/cisco/cfg_agent/test_aciasr1k_routing_driver.py
@@ -139,8 +139,9 @@ class ASR1kRoutingDriverAci(asr1ktest.ASR1kRoutingDriver):
         self.ex_gw_port['hosting_info']['global_config'] = [
             [self.GLOBAL_CFG_STRING_1, self.GLOBAL_CFG_STRING_2]]
         net = netaddr.IPNetwork(self.TEST_CIDR)
-        self.TEST_SNAT_POOL_ID = (driver.NAT_POOL_PREFIX +
-            self.TEST_SNAT_ID[:self.driver.NAT_POOL_ID_LEN] + '_nat_pool')
+        self.snat_prefix = (driver.NAT_POOL_PREFIX +
+            self.TEST_SNAT_ID[:self.driver.NAT_POOL_ID_LEN])
+        self.TEST_SNAT_POOL_ID = self.snat_prefix + '_nat_pool'
         self.TEST_CIDR_SNAT_IP = str(netaddr.IPAddress(net.first + 2))
         self.TEST_CIDR_SECONDARY_IP = str(netaddr.IPAddress(net.last - 1))
 

--- a/networking_cisco/tests/unit/cisco/cfg_agent/test_asr1k_routing_driver.py
+++ b/networking_cisco/tests/unit/cisco/cfg_agent/test_asr1k_routing_driver.py
@@ -68,6 +68,7 @@ class ASR1kRoutingDriver(base.BaseTestCase):
 
         self.vrf = ('nrouter-' + FAKE_ID)[:iosxe_driver.IosXeRoutingDriver.
                                           DEV_NAME_LEN]
+        self.snat_prefix = self.vrf
         self.driver._get_vrfs = mock.Mock(return_value=[self.vrf])
         self.ex_gw_ip = '20.0.0.31'
         # VIP is same as gw_ip for user visible router
@@ -460,7 +461,7 @@ class ASR1kRoutingDriver(base.BaseTestCase):
         self.assert_edit_run_cfg(
             csr_snippets.CREATE_ACL, cfg_params_create_acl)
 
-        pool_name = "%s_nat_pool" % self.vrf
+        pool_name = "%s_nat_pool" % self.snat_prefix
         cfg_params_dyn_trans = (acl_name, pool_name, self.vrf)
         self.assert_edit_run_cfg(
             snippets.SET_DYN_SRC_TRL_POOL, cfg_params_dyn_trans)
@@ -496,7 +497,8 @@ class ASR1kRoutingDriver(base.BaseTestCase):
         self.assert_edit_run_cfg(
             csr_snippets.CREATE_ACL, cfg_params_create_acl)
 
-        pool_name = "%s_nat_pool" % vrf
+        snat_prefix = self.snat_prefix + "-" + region_id
+        pool_name = "%s_nat_pool" % snat_prefix
         cfg_params_dyn_trans = (acl_name, pool_name, vrf)
         self.assert_edit_run_cfg(
             snippets.SET_DYN_SRC_TRL_POOL, cfg_params_dyn_trans)
@@ -518,7 +520,7 @@ class ASR1kRoutingDriver(base.BaseTestCase):
                    'acl_prefix': 'neutron_acl',
                    'vlan': self.vlan_int,
                    'port': self.port['id'][:8]}
-        pool_name = "%s_nat_pool" % self.vrf
+        pool_name = "%s_nat_pool" % self.snat_prefix
 
         cfg_params_dyn_trans = (acl_name, pool_name, self.vrf)
         self.assert_edit_run_cfg(
@@ -544,7 +546,8 @@ class ASR1kRoutingDriver(base.BaseTestCase):
                    'vlan': self.vlan_int,
                    'port': self.port['id'][:8]}
 
-        pool_name = "%s_nat_pool" % vrf
+        snat_prefix = self.snat_prefix + "-" + region_id
+        pool_name = "%s_nat_pool" % snat_prefix
 
         cfg_params_dyn_trans = (acl_name, pool_name, vrf)
         self.assert_edit_run_cfg(


### PR DESCRIPTION
The naming convention used to associate ACLs with
SNAT pools was wrong. This patch fixes that.

This closes issue #255

Signed-off-by: Thomas Bachman tbachman@yahoo.com
