### PR TITLE
Fix UT failures due to upstream commit

### DIFF
--- a/networking_cisco/tests/unit/cisco/device_manager/test_aci_vlan_trunking_driver.py
+++ b/networking_cisco/tests/unit/cisco/device_manager/test_aci_vlan_trunking_driver.py
@@ -109,7 +109,7 @@ class TestAciVLANTrunkingPlugDriverBase(
         #TODO(bobmel): Fix bug in test_extensions.py and we can remove the
         # below call to setup_config()
         self.setup_config()
-        self.plugin._core_plugin.mechanism_manager = mock.MagicMock()
+        self.l3_plugin._core_plugin.mechanism_manager = mock.MagicMock()
         plug = aci_vlan.AciVLANTrunkingPlugDriver()
         plug._apic_driver = mock.Mock()
         self.plugging_driver = plug
@@ -584,7 +584,7 @@ class TestAciVLANTrunkingPlugDriverGbp(
                         gw_port_db = self.core_plugin._get_ports_query(
                             u1_ctx, filters={'network_id': [ext_net_id]}).one()
                         _validate_allocation(
-                            self.plugin, u1_ctx, r1, gw_port_db,
+                            self.l3_plugin, u1_ctx, r1, gw_port_db,
                             test_info1, 0, hd, self.plugging_driver)
                         for i in range(1, len(test_info1['network_types'])):
                             cidr = '1.0.' + str(i) + '.0/24'
@@ -597,7 +597,7 @@ class TestAciVLANTrunkingPlugDriverGbp(
                                 port_db = self.core_plugin._get_port(
                                     u1_ctx, itfc_info['port_id'])
                                 _validate_allocation(
-                                    self.plugin, u1_ctx, r1,
+                                    self.l3_plugin, u1_ctx, r1,
                                     port_db, test_info1,
                                     i, hd, self.plugging_driver)
 
@@ -728,7 +728,7 @@ class TestAciVLANTrunkingPlugDriverNeutron(TestAciVLANTrunkingPlugDriverGbp):
         #TODO(bobmel): Fix bug in test_extensions.py and we can remove the
         # below call to setup_config()
         self.setup_config()
-        self.plugin._core_plugin.mechanism_manager = mock.MagicMock()
+        self.l3_plugin._core_plugin.mechanism_manager = mock.MagicMock()
         plug = aci_vlan.AciVLANTrunkingPlugDriver()
         plug.apic_driver.l3out_vlan_alloc.get_vlan_allocated = self._stub_vlan
         plug.apic_driver.per_tenant_context = True

--- a/networking_cisco/tests/unit/cisco/l3/test_aciasr1k_routertype_driver.py
+++ b/networking_cisco/tests/unit/cisco/l3/test_aciasr1k_routertype_driver.py
@@ -108,7 +108,7 @@ class AciAsr1kRouterTypeDriverTestCase(
                 r2 = router2['router']
                 # backlog processing will trigger one routers_updated
                 # notification containing r1 and r2
-                self.plugin._process_backlogged_routers()
+                self.l3_plugin._process_backlogged_routers()
                 # should have no global router yet
                 r_ids = {r1['id'], r2['id']}
                 self._verify_updated_routers(r_ids)
@@ -133,7 +133,7 @@ class AciAsr1kRouterTypeDriverTestCase(
             with self.router(tenant_id=tenant_id, external_gateway_info=ext_gw,
                              set_context=set_context) as router1:
                 r1 = router1['router']
-                self.plugin._process_backlogged_routers()
+                self.l3_plugin._process_backlogged_routers()
                 r1_after = self._show('routers', r1['id'])['router']
                 hd_id = r1_after[HOSTING_DEVICE_ATTR]
                 # should have one global router now
@@ -177,7 +177,7 @@ class AciAsr1kRouterTypeDriverTestCase(
             with self.router(tenant_id=tenant_id, external_gateway_info=ext_gw,
                              set_context=set_context) as router1:
                 r1 = router1['router']
-                self.plugin._process_backlogged_routers()
+                self.l3_plugin._process_backlogged_routers()
                 r1_after = self._show('routers', r1['id'])['router']
                 hd_id = r1_after[HOSTING_DEVICE_ATTR]
                 # should have one global router now
@@ -231,7 +231,7 @@ class AciAsr1kRouterTypeDriverTestCase(
                 r2 = router2['router']
                 # backlog processing will trigger one routers_updated
                 # notification containing r1 and r2
-                self.plugin._process_backlogged_routers()
+                self.l3_plugin._process_backlogged_routers()
                 r1_after = self._show('routers', r1['id'])['router']
                 hd_id = r1_after[HOSTING_DEVICE_ATTR]
                 r_ids = {r1['id'], r2['id']}
@@ -278,7 +278,7 @@ class AciAsr1kHARouterTypeDriverTestCase(
                 r1 = router1['router']
                 r2 = router2['router']
                 # backlog processing to schedule the routers
-                self.plugin._process_backlogged_routers()
+                self.l3_plugin._process_backlogged_routers()
                 # should have no global router yet
                 r_ids = [r1['id'], r2['id']]
                 self._verify_ha_created_routers(r_ids, 1, has_gw=[False,
@@ -317,7 +317,7 @@ class AciAsr1kHARouterTypeDriverTestCase(
                 self._delete('hosting_devices',
                              hds['hosting_devices'][1]['id'])
                 # backlog processing to schedule the routers
-                self.plugin._process_backlogged_routers()
+                self.l3_plugin._process_backlogged_routers()
                 self._verify_ha_created_routers([r1['id'], r2['id']])
                 r_spec = {'router': {l3.EXTERNAL_GW_INFO: None}}
                 self._update('routers', r1['id'], r_spec)

--- a/networking_cisco/tests/unit/cisco/l3/test_l3_router_appliance_plugin.py
+++ b/networking_cisco/tests/unit/cisco/l3/test_l3_router_appliance_plugin.py
@@ -708,12 +708,12 @@ class L3RouterApplianceGbpTestCase(test_l3.L3NatTestCaseMixin,
         manager.NeutronManager.get_service_plugins = self.saved_service_plugins
 
     def test_is_gbp_workflow(self):
-        self.assertTrue(self.plugin.is_gbp_workflow)
+        self.assertTrue(self.l3_plugin.is_gbp_workflow)
 
     def test_create_floatingip_gbp(self):
         kwargs = {'arg_list': (external_net.EXTERNAL,),
                   external_net.EXTERNAL: True}
-        self.plugin._update_fip_assoc = mock.Mock()
+        self.l3_plugin._update_fip_assoc = mock.Mock()
         with self.network(**kwargs) as net:
             with self.subnet(network=net, cidr='200.0.0.0/22') as sub:
                 subnet = sub['subnet']
@@ -726,7 +726,7 @@ class L3RouterApplianceGbpTestCase(test_l3.L3NatTestCaseMixin,
 
                 mock_drvr = mock.Mock()
                 mock_drvr.create_floatingip_precommit = _stub_modify_context
-                self.plugin._get_router_type_driver = mock.Mock(
+                self.l3_plugin._get_router_type_driver = mock.Mock(
                     return_value=mock_drvr
                 )
                 network = net['network']
@@ -735,22 +735,22 @@ class L3RouterApplianceGbpTestCase(test_l3.L3NatTestCaseMixin,
                                    'tenant_id': net['network']['tenant_id']}
                 }
                 ctx = n_context.get_admin_context()
-                self.plugin.create_floatingip(ctx, floating_ip)
+                self.l3_plugin.create_floatingip(ctx, floating_ip)
                 dummy_func.assert_called_once_with(ctx)
                 mock_drvr.create_floatingip_postcommit.assert_called_once_with(
                     ctx, mock.ANY)
-                self.plugin._update_fip_assoc.assert_called_once_with(ctx,
+                self.l3_plugin._update_fip_assoc.assert_called_once_with(ctx,
                     mock.ANY, mock.ANY, mock.ANY)
 
     def test_update_floatingip_gbp(self):
-        self.plugin._do_update_floatingip = mock.Mock()
+        self.l3_plugin._do_update_floatingip = mock.Mock()
         ctx = n_context.get_admin_context()
         TEST_FIP_UUID = _uuid()
         floating_ip = {
             'floatingip': {'floating_network_id': _uuid()}
         }
-        self.plugin.update_floatingip(ctx, TEST_FIP_UUID, floating_ip)
-        self.plugin._do_update_floatingip.assert_called_once_with(ctx,
+        self.l3_plugin.update_floatingip(ctx, TEST_FIP_UUID, floating_ip)
+        self.l3_plugin._do_update_floatingip.assert_called_once_with(ctx,
             TEST_FIP_UUID, floating_ip, add_fip=True)
 
 
@@ -769,28 +769,28 @@ class L3RouterApplianceNoGbpTestCase(test_l3.L3NatTestCaseMixin,
         super(L3RouterApplianceNoGbpTestCase, self).tearDown()
 
     def test_is_not_gbp_workflow(self):
-        self.assertFalse(self.plugin.is_gbp_workflow)
+        self.assertFalse(self.l3_plugin.is_gbp_workflow)
 
     def test_create_floatingip_gbp(self):
-        self.plugin._update_fip_assoc = mock.Mock()
-        self.plugin._create_floatingip_neutron = mock.Mock()
-        self.plugin._create_floatingip_gbp = mock.Mock()
+        self.l3_plugin._update_fip_assoc = mock.Mock()
+        self.l3_plugin._create_floatingip_neutron = mock.Mock()
+        self.l3_plugin._create_floatingip_gbp = mock.Mock()
         ctx = n_context.get_admin_context()
         floating_ip = {
             'floatingip': {'floating_network_id': _uuid()}
         }
-        self.plugin.create_floatingip(ctx, floating_ip)
-        self.plugin._create_floatingip_gbp.assert_not_called()
-        self.plugin._create_floatingip_neutron.assert_called_once_with(ctx,
+        self.l3_plugin.create_floatingip(ctx, floating_ip)
+        self.l3_plugin._create_floatingip_gbp.assert_not_called()
+        self.l3_plugin._create_floatingip_neutron.assert_called_once_with(ctx,
             floating_ip, initial_status=l3_constants.FLOATINGIP_STATUS_ACTIVE)
 
     def test_update_floatingip_no_gbp(self):
-        self.plugin._do_update_floatingip = mock.Mock()
+        self.l3_plugin._do_update_floatingip = mock.Mock()
         ctx = n_context.get_admin_context()
         TEST_FIP_UUID = _uuid()
         floating_ip = {
             'floatingip': {'floating_network_id': _uuid()}
         }
-        self.plugin.update_floatingip(ctx, TEST_FIP_UUID, floating_ip)
-        self.plugin._do_update_floatingip.assert_called_once_with(ctx,
+        self.l3_plugin.update_floatingip(ctx, TEST_FIP_UUID, floating_ip)
+        self.l3_plugin._do_update_floatingip.assert_called_once_with(ctx,
             TEST_FIP_UUID, floating_ip)


### PR DESCRIPTION
A commit (4d6ca0ec43ccb1216be99f9063482cc) to neutron has caused
several UTs for one of the Cisco L3 router plugins to fail.

This patch makes changes to so that the UTs pass again.

Signed-off-by: Thomas Bachman tbachman@yahoo.com
