### PR TITLE
Allow routers to be seen when changing L3 plugin

### DIFF
--- a/networking_cisco/tests/unit/cisco/l3/test_ha_l3_router_appliance_plugin.py
+++ b/networking_cisco/tests/unit/cisco/l3/test_ha_l3_router_appliance_plugin.py
@@ -14,6 +14,7 @@
 
 import copy
 import mock
+import unittest
 
 from oslo_config import cfg
 from oslo_log import log as logging
@@ -1474,6 +1475,10 @@ class HAL3RouterApplianceVMTestCase(
             args, kwargs = chk_method.call_args
             self.assertEqual(admin_ctx, args[0])
             self.assertIn(router['router']['id'], args[1])
+
+    @unittest.skip("VM HA with namespace not supported")
+    def test_add_namespace_binding(self):
+        pass
 
 
 class L3AgentHARouterApplianceTestCase(


### PR DESCRIPTION
If a neutron router was created by a different L3 plugin, when
the Cisco Router Service Plugin is selected and neutron restarted,
then the pre-existing neutron router will not be found when queried
because it doesn't have a RouterHostingDeviceBinding. This patch
adds the namespace binding for routers that don't have one, which
allows them to be seen when queried.

Signed-off-by: Thomas Bachman tbachman@yahoo.com
