### PR TITLE
Fix for exception in GBP with external segments

### DIFF
--- a/networking_cisco/plugins/cisco/device_manager/plugging_drivers/aci_vlan_trunking_driver.py
+++ b/networking_cisco/plugins/cisco/device_manager/plugging_drivers/aci_vlan_trunking_driver.py
@@ -377,7 +377,7 @@ class AciVLANTrunkingPlugDriver(hw_vlan.HwVLANTrunkingPlugDriver):
         the GBP workflow
         """
         prefix = network_name[:re.search(UUID_REGEX, network_name).start() - 1]
-        return prefix.strip(APIC_OWNED)
+        return prefix.replace(APIC_OWNED,'')
 
     def _get_ext_net_name_neutron(self, network_name):
         """Get the external network name


### PR DESCRIPTION
An exception is generated when using GBP mode and
using external segments that begin with the letter "a".
This patch fixes that bug.

Closes-issue: 339

Signed-off-by: Thomas Bachman tbachman@yahoo.com
