### PR TITLE
Fix GBP floatingip bug

### DIFF
--- a/networking_cisco/plugins/cisco/db/l3/l3_router_appliance_db.py
+++ b/networking_cisco/plugins/cisco/db/l3/l3_router_appliance_db.py
@@ -580,6 +580,7 @@ class L3RouterApplianceDBMixin(extraroute_db.ExtraRoute_dbonly_mixin):
         """
 
         result = None
+        driver = None
         fip = floatingip['floatingip']
         if not fip.get('subnet_id'):
             # NOTE: default router type must be ASR1k


### PR DESCRIPTION
This fixes an uninitialized variable exception, seen
while testing GBP with network services.

Signed-off-by: Thomas Bachman <tbachman@yahoo.com>