### PR TITLE
Fix delete floating IP for ACI driver

### DIFF
--- a/networking_cisco/plugins/cisco/l3/drivers/asr1k/aci_asr1k_routertype_driver.py
+++ b/networking_cisco/plugins/cisco/l3/drivers/asr1k/aci_asr1k_routertype_driver.py
@@ -202,11 +202,11 @@ class AciASR1kL3RouterDriver(asr1k.ASR1kL3RouterDriver):
 
     def delete_floatingip_precommit(self, context, fip_context):
         self.apic_driver.delete_floatingip_precommit(
-            context, fip_context.current)
+            context, fip_context.current['id'])
 
     def delete_floatingip_postcommit(self, context, fip_context):
         self.apic_driver.delete_floatingip_postcommit(
-            context, fip_context.current)
+            context, fip_context.current['id'])
 
     def _conditionally_add_global_router(self, context, router):
         """Create global router, if needed.

--- a/networking_cisco/tests/unit/cisco/etc/cisco_device_manager_plugin.ini
+++ b/networking_cisco/tests/unit/cisco/etc/cisco_device_manager_plugin.ini
@@ -129,6 +129,24 @@ tenant_bound=
 device_driver=networking_cisco.plugins.cisco.device_manager.hosting_device_drivers.noop_hd_driver.NoopHostingDeviceDriver
 plugging_driver=networking_cisco.plugins.cisco.device_manager.plugging_drivers.hw_vlan_trunking_driver.HwVLANTrunkingPlugDriver
 
+[cisco_hosting_device_template:8]
+name="ASR1k template with ACI"
+enabled=True
+host_category=Hardware
+service_types=router:FW:VPN
+image=
+flavor=
+default_credentials_id=1
+configuration_mechanism=
+protocol_port=22
+booting_time=360
+slot_capacity=2000
+desired_slots_free=0
+tenant_bound=
+device_driver=networking_cisco.plugins.cisco.device_manager.hosting_device_drivers.noop_hd_driver.NoopHostingDeviceDriver
+plugging_driver=networking_cisco.plugins.cisco.device_manager.plugging_drivers.hw_vlan_trunking_driver.HwVLANTrunkingPlugDriver
+
+
 
 [hosting_devices]
 [cisco_hosting_device:1]
@@ -179,6 +197,42 @@ protocol_port=22
 tenant_bound=
 auto_delete=False
 
+[cisco_hosting_device:5]
+template_id=8
+credentials_id=1
+name=dragon
+description=Main ASR1k serving region 1 with ACI
+device_id=SN:abcd1234efgh
+admin_state_up=True
+management_ip_address=10.0.100.5
+protocol_port=22
+tenant_bound=
+auto_delete=False
+
+[cisco_hosting_device:6]
+template_id=8
+credentials_id=1
+name=snake
+description=Secondary ASR1k serving region 1 with ACI
+device_id=SN:ijkl5678mnop
+admin_state_up=True
+management_ip_address=10.0.100.6
+protocol_port=22
+tenant_bound=
+auto_delete=False
+
+[cisco_hosting_device:7]
+template_id=8
+credentials_id=1
+name=scorpion
+description=ASR1k serving region 2 with ACI
+device_id=SN:qrst9012uvxy
+admin_state_up=True
+management_ip_address=10.0.100.7
+protocol_port=22
+tenant_bound=
+auto_delete=False
+
 
 [plugging_drivers]
 [HwVLANTrunkingPlugDriver:1]
@@ -196,3 +250,11 @@ external_net_interface_1=*:GigabitEthernet/2/0/1
 [HwVLANTrunkingPlugDriver:4]
 internal_net_interface_1=*:GigabitEthernet/1/0/3
 external_net_interface_1=*:GigabitEthernet/1/0/4
+
+[HwVLANTrunkingPlugDriver:5]
+internal_net_interface_1=*:GigabitEthernet/1/0/1
+external_net_interface_1=*:GigabitEthernet/2/0/1
+
+[HwVLANTrunkingPlugDriver:6]
+internal_net_interface_1=*:GigabitEthernet/1/0/1
+external_net_interface_1=*:GigabitEthernet/2/0/1

--- a/networking_cisco/tests/unit/cisco/etc/cisco_router_plugin.ini
+++ b/networking_cisco/tests/unit/cisco/etc/cisco_router_plugin.ini
@@ -74,3 +74,16 @@ scheduler=networking_cisco.plugins.cisco.l3.schedulers.l3_router_hosting_device_
 driver=networking_cisco.plugins.cisco.l3.drivers.asr1k.asr1k_routertype_driver.ASR1kL3RouterDriver
 cfg_agent_service_helper=networking_cisco.plugins.cisco.cfg_agent.service_helpers.routing_svc_helper.RoutingServiceHelper
 cfg_agent_driver=networking_cisco.plugins.cisco.cfg_agent.device_drivers.asr1k.asr1k_routing_driver.ASR1kRoutingDriver
+
+[cisco_router_type:8]
+name=AciASR1k_Neutron_router
+description="Neutron router implemented in Cisco ASR1k device with ACI"
+template_id=8
+ha_enabled_by_default=False
+shared=True
+slot_need=2
+scheduler=networking_cisco.plugins.cisco.l3.schedulers.l3_router_hosting_device_scheduler.L3RouterHostingDeviceHARandomScheduler
+driver=networking_cisco.plugins.cisco.l3.drivers.asr1k.aci_asr1k_routertype_driver.AciASR1kL3RouterDriver
+cfg_agent_service_helper=networking_cisco.plugins.cisco.cfg_agent.service_helpers.routing_svc_helper.RoutingServiceHelper
+cfg_agent_driver=networking_cisco.plugins.cisco.cfg_agent.device_drivers.asr1k.asr1k_routing_driver.ASR1kRoutingDriver
+

--- a/networking_cisco/tests/unit/cisco/etc/ha/cisco_router_plugin.ini
+++ b/networking_cisco/tests/unit/cisco/etc/ha/cisco_router_plugin.ini
@@ -74,3 +74,15 @@ scheduler=networking_cisco.plugins.cisco.l3.schedulers.l3_router_hosting_device_
 driver=networking_cisco.plugins.cisco.l3.drivers.asr1k.asr1k_routertype_driver.ASR1kL3RouterDriver
 cfg_agent_service_helper=networking_cisco.plugins.cisco.cfg_agent.service_helpers.routing_svc_helper.RoutingServiceHelper
 cfg_agent_driver=networking_cisco.plugins.cisco.cfg_agent.device_drivers.asr1k.asr1k_routing_driver.ASR1kRoutingDriver
+
+[cisco_router_type:8]
+name=AciASR1k_Neutron_router
+description="Neutron router implemented in Cisco ASR1k device with ACI"
+template_id=8
+ha_enabled_by_default=True
+shared=True
+slot_need=2
+scheduler=networking_cisco.plugins.cisco.l3.schedulers.l3_router_hosting_device_scheduler.L3RouterHostingDeviceHARandomScheduler
+driver=networking_cisco.plugins.cisco.l3.drivers.asr1k.aci_asr1k_routertype_driver.AciASR1kL3RouterDriver
+cfg_agent_service_helper=networking_cisco.plugins.cisco.cfg_agent.service_helpers.routing_svc_helper.RoutingServiceHelper
+cfg_agent_driver=networking_cisco.plugins.cisco.cfg_agent.device_drivers.asr1k.asr1k_routing_driver.ASR1kRoutingDriver


### PR DESCRIPTION
The delete floating IP precommit/postcommit calls
were passing the entire floating IP DB object. They
should only pass the floating IP ID.

Signed-off-by: Thomas Bachman <tbachman@yahoo.com>