### PR TITLE
Fix router lookup

### DIFF
--- a/networking_cisco/plugins/cisco/db/l3/l3_router_appliance_db.py
+++ b/networking_cisco/plugins/cisco/db/l3/l3_router_appliance_db.py
@@ -146,13 +146,13 @@ class L3RouterApplianceDBMixin(extraroute_db.ExtraRoute_dbonly_mixin):
 
     def _cisco_router_model_hook(self, context, original_model, query):
         original_query = query
-        query = original_query.outerjoin(
+        query = original_query.join(
             l3_models.RouterHostingDeviceBinding,
             (original_model.id ==
                 l3_models.RouterHostingDeviceBinding.router_id))
         if original_query.first() and not query.first():
             self._add_namespace_binding(context, original_query.first())
-            query = original_query.outerjoin(
+            query = original_query.join(
                 l3_models.RouterHostingDeviceBinding,
                 (original_model.id ==
                     l3_models.RouterHostingDeviceBinding.router_id))


### PR DESCRIPTION
The get hook for neutron routers does an outerjoin with
the router binding. This should be changed to a join,
and if there is no intersection, a namespace router
binding should be used.

Signed-off-by: Thomas Bachman <tbachman@yahoo.com>