### PR TITLE
Allow tenant networks to multiple routers

### DIFF
--- a/networking_cisco/plugins/cisco/l3/drivers/asr1k/aci_asr1k_routertype_driver.py
+++ b/networking_cisco/plugins/cisco/l3/drivers/asr1k/aci_asr1k_routertype_driver.py
@@ -149,8 +149,9 @@ class AciASR1kL3RouterDriver(asr1k.ASR1kL3RouterDriver):
             context, router_context)
 
     def add_router_interface_precommit(self, context, r_port_context):
-        super(AciASR1kL3RouterDriver, self).add_router_interface_precommit(
-            context, r_port_context)
+        # NB: this purposely doesn't call the superclass, as the
+        # ACI integration allows for the possibility for a tenant
+        # network to be connected to more than one neutron router
         pass
 
     def add_router_interface_postcommit(self, context, r_port_context):

--- a/networking_cisco/tests/unit/cisco/l3/test_aciasr1k_routertype_driver.py
+++ b/networking_cisco/tests/unit/cisco/l3/test_aciasr1k_routertype_driver.py
@@ -303,6 +303,14 @@ class AciAsr1kRouterTypeDriverTestCase(
                 self._verify_routers({r1['id'], r2['id']}, {ext_net_1_id},
                                      hd_id)
 
+    @unittest.skip("Behavior allowed in ACI integration")
+    def test_router_interface_add_refused_for_unsupported_topology(self):
+        pass
+
+    @unittest.skip("Behavior allowed in ACI integration")
+    def test_router_interface_add_refused_for_unsupported_topology_dt(self):
+        pass
+
 
 class AciAsr1kHARouterTypeDriverTestCase(
         asr1k_test.Asr1kHARouterTypeDriverTestCase):
@@ -342,6 +350,15 @@ class AciAsr1kHARouterTypeDriverTestCase(
                     ctx, floating_ip['id'])
                 self.drv.delete_floatingip_postcommit.assert_called_once_with(
                     ctx, floating_ip['id'])
+
+    @unittest.skip("Behavior allowed in ACI integration")
+    def test_router_interface_add_refused_for_unsupported_topology(self):
+        pass
+
+    @unittest.skip("Behavior allowed in ACI integration")
+    def test_router_interface_add_refused_for_unsupported_topology_dt(self):
+        pass
+
 
 
 class L3CfgAgentAciAsr1kRouterTypeDriverTestCase(


### PR DESCRIPTION
This patch relaxes the constraint for ASR1k routers, where a
tenant network can connect to multiple neutron routers when
using ACI.

Closes-issue: 447