### PR TITLE
Fix incorrect SNAT subnet ID

### DIFF
--- a/networking_cisco/plugins/cisco/device_manager/plugging_drivers/aci_vlan_trunking_driver.py
+++ b/networking_cisco/plugins/cisco/device_manager/plugging_drivers/aci_vlan_trunking_driver.py
@@ -258,7 +258,7 @@ class AciVLANTrunkingPlugDriver(hw_vlan.HwVLANTrunkingPlugDriver):
                     # network
                     if not self._snat_subnet_for_ext_net(context, subnet, net):
                         continue
-                    snat_subnet = {'id': router['tenant_id'],
+                    snat_subnet = {'id': subnet['id'],
                                    'ip': snat_ips['host_snat_ip'],
                                    'cidr': subnet['cidr']}
                     hosting_info['snat_subnets'].append(snat_subnet)

--- a/networking_cisco/tests/unit/cisco/device_manager/test_aci_vlan_trunking_driver.py
+++ b/networking_cisco/tests/unit/cisco/device_manager/test_aci_vlan_trunking_driver.py
@@ -447,7 +447,7 @@ class TestAciVLANTrunkingPlugDriverGbp(
                 self.plugging_driver.extend_hosting_port_info(ctx,
                     fake_port_db_obj, hosting_device, hosting_info)
                 self.assertEqual(hosting_info['snat_subnets'],
-                                 [{'id': r1['tenant_id'],
+                                 [{'id': sn1['id'],
                                    'ip': FAKE_IP,
                                    'cidr': sn1['cidr']}])
 
@@ -815,7 +815,7 @@ class TestAciVLANTrunkingPlugDriverNeutron(TestAciVLANTrunkingPlugDriverGbp):
                     self.plugging_driver.extend_hosting_port_info(ctx,
                         fake_port_db_obj, hosting_device, hosting_info)
                     self.assertEqual(hosting_info['snat_subnets'],
-                                     [{'id': r1['tenant_id'],
+                                     [{'id': sn1['id'],
                                        'ip': FAKE_IP,
                                        'cidr': sn1['cidr']}],
                                      hosting_info['snat_subnets'])


### PR DESCRIPTION
The plugging driver for ACI was passing the tenant ID
of the neutron router owning the SNAT subnet. Instead,
it should use the ID of the SNAT subnet itself.

Closes-issue: #452