### PR TITLE
Fix for multiple L3 outs in same ACI VRF

### DIFF
--- a/networking_cisco/plugins/cisco/cfg_agent/device_drivers/asr1k/aci_asr1k_routing_driver.py
+++ b/networking_cisco/plugins/cisco/cfg_agent/device_drivers/asr1k/aci_asr1k_routing_driver.py
@@ -15,6 +15,7 @@
 import hashlib
 import logging
 import netaddr
+import uuid
 
 from oslo_config import cfg
 
@@ -341,6 +342,13 @@ class AciASR1kRoutingDriver(asr1k.ASR1kRoutingDriver):
         # This could happen if it's the global router
         if not vrf_tag:
             return None
+        vlan = ext_gw_port['hosting_info'].get('segmentation_id')
+        if not vlan:
+            return None
+        # Create a unique VRF by adding the VLAN to the existing
+        # VRF ID, and creating a new UUID using an MD5 hash
+        vrf_string = vrf_tag.encode('utf-8') + hex(vlan)[2:]
+        vrf_tag = str(uuid.uuid3(uuid.NAMESPACE_DNS, vrf_string))
         vrf_id = (helper.N_ROUTER_PREFIX + vrf_tag)[:self.DEV_NAME_LEN]
         is_multi_region_enabled = cfg.CONF.multi_region.enable_multi_region
 

--- a/networking_cisco/tests/unit/cisco/l3/test_aciasr1k_routertype_driver.py
+++ b/networking_cisco/tests/unit/cisco/l3/test_aciasr1k_routertype_driver.py
@@ -360,7 +360,6 @@ class AciAsr1kHARouterTypeDriverTestCase(
         pass
 
 
-
 class L3CfgAgentAciAsr1kRouterTypeDriverTestCase(
         asr1k_test.L3CfgAgentAsr1kRouterTypeDriverTestCase):
 


### PR DESCRIPTION
When multiple L3 Outs are used in the same VRF in ACI, then
each VRF+L3 Out combo needs its own VRF in the ASR. This is
needed to overcome issues with how things like default routes,
ACLs, and SNAT IPs are managed.

This patch changes the mapping from simply the VRF ID, to instead
use the VRF ID hashed with the VLAN used on the internal subinterface,
which maps to an L3 Out within that VRF.

Closes-issue: #448