### PR TITLE
Additional fix for DBDuplicateEntry

### DIFF
--- a/networking_cisco/plugins/cisco/db/l3/l3_router_appliance_db.py
+++ b/networking_cisco/plugins/cisco/db/l3/l3_router_appliance_db.py
@@ -130,12 +130,12 @@ class L3RouterApplianceDBMixin(extraroute_db.ExtraRoute_dbonly_mixin):
         l3.ROUTERS, DICT_EXTEND_FUNCTIONS)
 
     def _add_namespace_binding(self, context, router_db):
-        router_type_id = self.get_namespace_router_type_id(context)
-        auto_schedule = cfg.CONF.routing.auto_schedule
-        share_host = cfg.CONF.routing.share_hosting_device
         # Put in a try/except, as multiple contexts
         # may attempt to add the binding
         try:
+            router_type_id = self.get_namespace_router_type_id(context)
+            auto_schedule = cfg.CONF.routing.auto_schedule
+            share_host = cfg.CONF.routing.share_hosting_device
             with context.session.begin(subtransactions=True):
                 r_hd_b_db = l3_models.RouterHostingDeviceBinding(
                     router_id=router_db['id'],


### PR DESCRIPTION
The try/except needs to cover the entire method, as getting
the namespace router in multiple contexts can also lead to
DBDuplicateEntry exceptions (e.g. creating initial router
templates in the DB).

Closes-issue: 457