### PR TITLE
Fix VRF lookups

### DIFF
--- a/networking_cisco/plugins/cisco/cfg_agent/device_drivers/asr1k/aci_asr1k_routing_driver.py
+++ b/networking_cisco/plugins/cisco/cfg_agent/device_drivers/asr1k/aci_asr1k_routing_driver.py
@@ -335,13 +335,16 @@ class AciASR1kRoutingDriver(asr1k.ASR1kRoutingDriver):
         # that isn't there, look for the router we used to have
         # (indicates that the gateway port is being cleared, but
         # means that the infromation is still useful)
-        ext_gw_port = ri.router.get('gw_port') or ri.ex_gw_port
-        if not ext_gw_port:
+        if (ri.router.get('gw_port') and
+                ri.router['gw_port'].get('hosting_info') and
+                ri.router['gw_port']['hosting_info'].get('vrf_id')):
+            ext_gw_port = ri.router['gw_port']
+        elif (ri.ex_gw_port and ri.ex_gw_port.get('hosting_info') and
+                ri.ex_gw_port['hosting_info'].get('vrf_id')):
+            ext_gw_port = ri.ex_gw_port
+        else:
             return None
-        vrf_tag = ext_gw_port['hosting_info'].get('vrf_id')
-        # This could happen if it's the global router
-        if not vrf_tag:
-            return None
+        vrf_tag = ext_gw_port['hosting_info']['vrf_id']
         vlan = ext_gw_port['hosting_info'].get('segmentation_id')
         if not vlan:
             return None

--- a/networking_cisco/plugins/cisco/device_manager/plugging_drivers/aci_vlan_trunking_driver.py
+++ b/networking_cisco/plugins/cisco/device_manager/plugging_drivers/aci_vlan_trunking_driver.py
@@ -303,7 +303,8 @@ class AciVLANTrunkingPlugDriver(hw_vlan.HwVLANTrunkingPlugDriver):
             # empty-string tenant IDs
             if router.get(ROUTER_ROLE_ATTR):
                 return
-            hosting_info['vrf_id'] = details['vrf_id']
+            if details and details.get('vrf_id'):
+                hosting_info['vrf_id'] = details['vrf_id']
             if ext_dict.get('global_config'):
                 hosting_info['global_config'] = (
                     ext_dict['global_config'])

--- a/networking_cisco/tests/unit/cisco/cfg_agent/test_aciasr1k_routing_driver.py
+++ b/networking_cisco/tests/unit/cisco/cfg_agent/test_aciasr1k_routing_driver.py
@@ -175,6 +175,22 @@ class ASR1kRoutingDriverAci(asr1ktest.ASR1kRoutingDriver):
                 mock_calls[index][2]['config'],
                 confstr)
 
+    def test_get_vrf_name(self):
+        # First check using router info
+        vrf = self.driver._get_vrf_name(self.ri)
+        self.assertEqual(self.vrf, vrf)
+
+        # Verify that when there is no valid
+        # gateway port, we don't hvae a VRF
+        ri = routing_svc_helper.RouterInfo(FAKE_ID, {})
+        vrf = self.driver._get_vrf_name(ri)
+        self.assertIsNone(vrf)
+
+        # Then check using previous gateway port
+        ri.ex_gw_port = self.ex_gw_port
+        vrf = self.driver._get_vrf_name(ri)
+        self.assertEqual(self.vrf, vrf)
+
     def test_internal_network_added(self):
         cfg.CONF.set_override('enable_multi_region', False, 'multi_region')
         self.driver.internal_network_added(self.ri, self.port)


### PR DESCRIPTION
There are cases where the VRF IDs need to be looked
up using previous state. This patch fixes an exception
found when previous VRF IDs weren't used.

Closes-issue: 467