### PR TITLE
SNAT IDs need to be uniqified by VRFs

### DIFF
--- a/networking_cisco/plugins/cisco/device_manager/plugging_drivers/aci_vlan_trunking_driver.py
+++ b/networking_cisco/plugins/cisco/device_manager/plugging_drivers/aci_vlan_trunking_driver.py
@@ -13,6 +13,7 @@
 #    under the License.
 
 import re
+import uuid
 import yaml
 
 from neutron.extensions import l3
@@ -266,7 +267,13 @@ class AciVLANTrunkingPlugDriver(hw_vlan.HwVLANTrunkingPlugDriver):
                     # network
                     if not self._snat_subnet_for_ext_net(context, subnet, net):
                         continue
-                    snat_subnet = {'id': subnet['id'],
+                    # Uniquify the SNAT ID per VRF. This needs to be
+                    # Changed to handle different SNAT IP allocation
+                    # strategies, once they're supported
+                    snat_id = hosting_info['vrf_id'] + subnet['id']
+                    snat_id = str(uuid.uuid3(uuid.NAMESPACE_DNS,
+                                             snat_id.encode('utf-8')))
+                    snat_subnet = {'id': snat_id,
                                    'ip': snat_ips['host_snat_ip'],
                                    'cidr': subnet['cidr']}
                     hosting_info['snat_subnets'].append(snat_subnet)

--- a/networking_cisco/tests/unit/cisco/device_manager/test_aci_vlan_trunking_driver.py
+++ b/networking_cisco/tests/unit/cisco/device_manager/test_aci_vlan_trunking_driver.py
@@ -13,8 +13,9 @@
 #    under the License.
 
 import copy
-
 import mock
+import uuid
+
 from oslo_log import log as logging
 from oslo_utils import fileutils
 from oslo_utils import uuidutils
@@ -486,14 +487,18 @@ class TestAciVLANTrunkingPlugDriverGbp(
                 fake_port_db_obj = FakePortDb('fakeuuid', sn1['network_id'],
                     bc.constants.DEVICE_OWNER_ROUTER_GW, r1['id'])
                 fake_port_db_obj.hosting_info['segmentation_id'] = 40
+                fake_port_db_obj.hosting_info['vrf_id'] = _uuid()
                 hosting_device = {'id': '00000000-0000-0000-0000-000000000002'}
                 tenant_id = 'tenant_uuid1'
                 ctx = context.Context('', tenant_id, is_admin=True)
                 self._set_apic_driver_mocks(r1)
                 self.plugging_driver.extend_hosting_port_info(ctx,
                     fake_port_db_obj, hosting_device, hosting_info)
+                snat_id = hosting_info['vrf_id'] + sn1['id']
+                snat_id = str(uuid.uuid3(uuid.NAMESPACE_DNS,
+                                         snat_id.encode('utf-8')))
                 self.assertEqual(hosting_info['snat_subnets'],
-                                 [{'id': sn1['id'],
+                                 [{'id': snat_id,
                                    'ip': FAKE_IP,
                                    'cidr': sn1['cidr']}])
 
@@ -853,6 +858,7 @@ class TestAciVLANTrunkingPlugDriverNeutron(TestAciVLANTrunkingPlugDriverGbp):
                     fake_port_db_obj = FakePortDb('fakeuuid', ext_net_id,
                         bc.constants.DEVICE_OWNER_ROUTER_GW, r1['id'])
                     fake_port_db_obj.hosting_info['segmentation_id'] = 40
+                    fake_port_db_obj.hosting_info['vrf_id'] = _uuid()
                     hosting_device = {'id':
                                       '00000000-0000-0000-0000-000000000002'}
                     tenant_id = 'tenant_uuid1'
@@ -860,8 +866,11 @@ class TestAciVLANTrunkingPlugDriverNeutron(TestAciVLANTrunkingPlugDriverGbp):
                     self._set_apic_driver_mocks(r1)
                     self.plugging_driver.extend_hosting_port_info(ctx,
                         fake_port_db_obj, hosting_device, hosting_info)
+                    snat_id = hosting_info['vrf_id'] + sn1['id']
+                    snat_id = str(uuid.uuid3(uuid.NAMESPACE_DNS,
+                                             snat_id.encode('utf-8')))
                     self.assertEqual(hosting_info['snat_subnets'],
-                                     [{'id': sn1['id'],
+                                     [{'id': snat_id,
                                        'ip': FAKE_IP,
                                        'cidr': sn1['cidr']}],
                                      hosting_info['snat_subnets'])


### PR DESCRIPTION
The same SNAT ID was being used for multiple SNAT IPs,
which caused the configuration agent to not use all of
the SNAT IPs. This patch uniquifies the SNAT IDs per VRF,
in order to ensure that the configuration agent uses all
of the SNAT IPs.

Closes-issue: 471