### PR TITLE
Fix ASR configuration for singel VRF

### DIFF
--- a/networking_cisco/plugins/cisco/cfg_agent/device_drivers/asr1k/aci_asr1k_routing_driver.py
+++ b/networking_cisco/plugins/cisco/cfg_agent/device_drivers/asr1k/aci_asr1k_routing_driver.py
@@ -296,7 +296,7 @@ class AciASR1kRoutingDriver(asr1k.ASR1kRoutingDriver):
                 params = {'key': e}
                 raise cfg_exc.DriverExpectedKeyNotSetException(**params)
 
-    def internal_network_removed(self, ri, port, itfc_deleted=False):
+    def internal_network_removed(self, ri, port, itfc_deleted=True):
         if_configs = port['hosting_info'].get('interface_config')
         if if_configs and isinstance(if_configs, list) and itfc_deleted:
             self._remove_interface_config(ri, port, if_configs)


### PR DESCRIPTION
There were some configuration cases that weren't
handled correctly when using a single VRF in ACI.
Specifically, the "nat inside" and default route
for a given VRF in the ASR were being deleted
incorrectly. This patch addresses those.

Closes-issue: 472